### PR TITLE
Fix major typo in the constructor method

### DIFF
--- a/src/fen_parser/base_parser.py
+++ b/src/fen_parser/base_parser.py
@@ -8,7 +8,7 @@ from abc import ABC, abstractmethod
 
 class BaseParser(ABC):
 
-	def __init(self, board: 'Board'):
+	def __init__(self, board: 'Board'):
 		self.board = board
 
 	@abstractmethod


### PR DESCRIPTION
Fixed a major typing error in the constructor method for the BaseParser class. Previously, it was '__init' instead of '__init__'.