### PR TITLE
Add a menu next to the board

### DIFF
--- a/src/chess/board.py
+++ b/src/chess/board.py
@@ -51,13 +51,8 @@ class Board:
 		# Set up the chessboard
 		self._create_board(fen_str)
 
-	def get_fullmove_number(self):
-		"""Returns the full move number of the current game."""
-		return (self._move_number + 2) // 2
-
-	def increment_move_number(self, increment=1):
-		"""Increments the number of half moves made."""
-		self._move_number += increment
+		# Define borders of the board
+		self.border_rect = self._define_borders()
 
 	def _create_board(self, fen_str: str):
 		"""Create the chessboard with squares, pieces and coordinates around the board."""
@@ -119,6 +114,13 @@ class Board:
 
 		return coordinates
 
+	def _define_borders(self) -> pg.Rect:
+		left = self.squares[0].rect.left
+		top = self.squares[0].rect.top
+		length = 8*Square.SQUARE_SIZE
+
+		return pg.Rect(left, top, length, length)
+
 	# TODO: Use binary search since the data is sorted or use dictionaries
 	# Getters
 	def get_square_by_coords(self, x: int, y: int) -> Union[Square, None]:
@@ -150,6 +152,14 @@ class Board:
 				pieces_to_return.append(piece)
 
 		return pieces_to_return
+
+	def get_fullmove_number(self):
+		"""Returns the full move number of the current game."""
+		return (self._move_number + 2) // 2
+
+	def increment_move_number(self, increment=1):
+		"""Increments the number of half moves made."""
+		self._move_number += increment
 
 	def render(self, dragged_piece: BasePiece):
 		"""Render the chessboard."""

--- a/src/game/game.py
+++ b/src/game/game.py
@@ -13,13 +13,17 @@ from graphics import (
 	SCREEN_PROPERTIES, WINDOW_TITLE,
 	BACKGROUND_COLOR, FPS
 )
-from utils import get_dragged_piece, get_release_square
+from utils import (
+		get_dragged_piece, 
+		get_release_square, 
+		point_in_rect
+	)
 
 # Chess imports
 from chess import Board, Move, Square
 from fen_parser.board_parser import BoardParser
 
-from .menu import ChessMenu
+from .menu import ChessMenu, ChessMenuHandler
 
 
 class ChessGame(Display):
@@ -35,6 +39,7 @@ class ChessGame(Display):
 
 		# Chess screen menu
 		self.chess_menu = ChessMenu()
+		self.chess_menu_handler = ChessMenuHandler(self.board_parser)
 
 		# Flags
 		self.dragged_piece: Union['BasePiece', None] = None
@@ -76,14 +81,20 @@ class ChessGame(Display):
 				# Exit the application.
 				sysexit(1)
 			elif event.type == pg.MOUSEBUTTONDOWN:
-				# Start dragging a piece if it was clicked on.
-				self.dragged_piece = get_dragged_piece(self.board)
-				if self.dragged_piece is not None:
-					# Highlight the dragged piece's current square.
-					self.dragged_piece.square.highlight(Square.CURRENT_SQUARE_HIGHLIGHT)
+				mouse_x, mouse_y = pg.mouse.get_pos()
+				if point_in_rect(mouse_x, mouse_y, self.board.border_rect):  # check chessboard
+					# Start dragging a piece if it was clicked on.
+					self.dragged_piece = get_dragged_piece(self.board)
+					if self.dragged_piece is not None:
+						# Highlight the dragged piece's current square.
+						self.dragged_piece.square.highlight(Square.CURRENT_SQUARE_HIGHLIGHT)
 
-					# Get possible squares the piece can move to.
-					self.possible_squares = self.dragged_piece.get_possible_moves(self.board)
+						# Get possible squares the piece can move to.
+						self.possible_squares = self.dragged_piece.get_possible_moves(self.board)
+				else:  # then it must be the chess menu
+					pressed_widget = self.chess_menu.get_pressed_widget(mouse_x, mouse_y)
+					if pressed_widget is not None:
+						self.chess_menu_handler.handle(pressed_widget)
 			elif event.type == pg.MOUSEBUTTONUP:
 				# Release the piece being dragged if it exists.
 				if self.is_dragging:

--- a/src/game/game.py
+++ b/src/game/game.py
@@ -19,6 +19,8 @@ from utils import get_dragged_piece, get_release_square
 from chess import Board, Move, Square
 from fen_parser.board_parser import BoardParser
 
+from .menu import ChessMenu
+
 
 class ChessGame(Display):
 	"""The class that represents the game."""
@@ -27,8 +29,12 @@ class ChessGame(Display):
 		"""Initialize pygame, the screen and the board."""
 		super().__init__(SCREEN_PROPERTIES, WINDOW_TITLE, FPS, BACKGROUND_COLOR)
 
+		# Board
 		self.board: Board = Board(self.screen, fen_str)
 		self.board_parser: BoardParser = BoardParser(self.board)
+
+		# Chess screen menu
+		self.chess_menu = ChessMenu()
 
 		# Flags
 		self.dragged_piece: Union['BasePiece', None] = None
@@ -89,8 +95,8 @@ class ChessGame(Display):
 
 	def render(self):
 		super().render()
-
 		self.board.render(self.dragged_piece)
+		self.chess_menu.render(self.screen)
 
 	def update(self):
 		if self.dragged_piece is not None:

--- a/src/game/game.py
+++ b/src/game/game.py
@@ -43,30 +43,11 @@ class ChessGame(Display):
 		self.chess_menu_handler: ChessMenuHandler = ChessMenuHandler(self.board_parser)
 
 		# Flags
-		# TODO: Add MoveHandler and remove is_dragging property
+		# TODO: Add MoveHandler
 		self.dragged_piece: Union['BasePiece', None] = None
 		self.possible_squares: Union[List, None] = None
 
 		self.pressed_widget: Union['MenuWidget', None] = None
-
-	# Flags as properties
-	@property
-	def is_dragging(self) -> bool:
-		"""Flag for checking if a piece is actually being dragged by the user/player."""
-		return True if self.dragged_piece is not None else False
-
-	@is_dragging.setter
-	def is_dragging(self, value) -> None:
-		self.dragged_piece = value
-
-	@property
-	def is_pressing_widget(self) -> bool:
-		"""Flag for checking if a widget is being pressed."""
-		return True if self.pressed_widget is not None else False
-
-	@is_pressing_widget.setter
-	def is_pressing_widget(self, value):
-		self.pressed_widget = value
 
 	def move_piece(self, to_square: 'Square') -> None:
 		"""Move the dragged piece to a new square."""
@@ -93,7 +74,7 @@ class ChessGame(Display):
 				sysexit(1)
 			elif event.type == pg.MOUSEBUTTONDOWN:
 				mouse_x, mouse_y = pg.mouse.get_pos()
-				if point_in_rect(mouse_x, mouse_y, self.board.border_rect):  # check chessboard
+				if point_in_rect(mouse_x, mouse_y, self.board.border_rect):  # Chessboard
 					# Start dragging a piece if it was clicked on.
 					self.dragged_piece = get_dragged_piece(self.board)
 					if self.dragged_piece is not None:
@@ -102,22 +83,27 @@ class ChessGame(Display):
 
 						# Get possible squares the piece can move to.
 						self.possible_squares = self.dragged_piece.get_possible_moves(self.board)
-				else:  # then it must be the chess menu
+				else:  # Chess menu
+					# Highlight and handle pressed widget if a widget was clicked on.
 					self.pressed_widget = self.chess_menu.get_pressed_widget(mouse_x, mouse_y)
 					if self.pressed_widget is not None:
 						self.chess_menu_handler.handle(self.pressed_widget)
 						self.pressed_widget.highlight()
 			elif event.type == pg.MOUSEBUTTONUP:
 				# Release the piece being dragged if it exists.
-				if self.is_dragging:
+				if self.dragged_piece is not None:
 					to_square = get_release_square(self.board)
 					self.move_piece(to_square)
 
 					# Reset dragged piece reference after making the move
-					self.is_dragging = None
+					self.dragged_piece = None
 
-				if self.is_pressing_widget:
+				# Unhighlight the pressed widget if it exists.
+				if self.pressed_widget is not None:
 					self.pressed_widget.unhighlight()
+
+					# Reset pressed widget reference
+					self.pressed_widget = None
 
 	def render(self):
 		super().render()

--- a/src/game/launcher/launcher.py
+++ b/src/game/launcher/launcher.py
@@ -13,6 +13,8 @@ from .fen_gui import FENFrame
 from chess import Board
 from fen_parser import validate_fen
 
+import ctypes  # for dpi awareness
+
 
 # Constants
 LAUNCHER_FEN_KEY = 'fen'
@@ -40,6 +42,10 @@ class LauncherWindow(tk.Tk, WidgetMixin):
 
 	def __init__(self, launcher_dict: Dict):
 		"""Initialize the window and its properties."""
+		# Improve resolution - we do it here because doing in it in the
+		# main() function doesn't work for some reason - TODO!
+		ctypes.windll.shcore.SetProcessDpiAwareness(1)
+
 		super(LauncherWindow, self).__init__()
 		self.launcher_dict = launcher_dict
 

--- a/src/game/menu/__init__.py
+++ b/src/game/menu/__init__.py
@@ -1,1 +1,2 @@
 from .chess_menu import ChessMenu, ChessMenuHandler
+from .menu_widget import MenuWidget

--- a/src/game/menu/__init__.py
+++ b/src/game/menu/__init__.py
@@ -1,1 +1,1 @@
-from .chess_menu import ChessMenu
+from .chess_menu import ChessMenu, ChessMenuHandler

--- a/src/game/menu/__init__.py
+++ b/src/game/menu/__init__.py
@@ -1,0 +1,1 @@
+from .chess_menu import ChessMenu

--- a/src/game/menu/chess_menu.py
+++ b/src/game/menu/chess_menu.py
@@ -1,0 +1,31 @@
+# Typing
+from typing import List, Union
+
+from graphics import Renderable
+
+from .menu_widget import MenuWidget
+
+# remove this later, move colors into its own module
+import pygame as pg
+
+
+class ChessMenu(Renderable):
+	"""The menu that is visible when along with the chessboard."""
+	
+	def __init__(self):
+		"""Initialize the widgets on the menu."""
+		self.board_fen_widget = MenuWidget(10, 100, 'GET FEN', pg.Color('white'), pg.Color('black'))
+
+		self.widgets = self._init_widget_list()
+
+	def get_pressed_widget(self) -> Union[MenuWidget, None]:
+		for widget in self.widgets:
+			pass
+
+	def _init_widget_list(self) -> List:
+		"""Initialize the list that contains every widget on the menu."""
+		return [getattr(self, key) for key in vars(self).keys()]
+
+	def render(self, surface):
+		for widget in self.widgets:
+			widget.render(surface)

--- a/src/game/menu/chess_menu.py
+++ b/src/game/menu/chess_menu.py
@@ -1,12 +1,18 @@
 # Typing
-from typing import List, Union
+from typing import List, Union, TYPE_CHECKING
+if TYPE_CHECKING:
+	from chess import Board
 
+# Imports from my packages
 from graphics import Renderable
-
+from fen_parser.board_parser import BoardParser
 from .menu_widget import MenuWidget
+from utils import point_in_rect
 
 # remove this later, move colors into its own module
 import pygame as pg
+
+import tkinter as tk
 
 
 class ChessMenu(Renderable):
@@ -14,18 +20,44 @@ class ChessMenu(Renderable):
 	
 	def __init__(self):
 		"""Initialize the widgets on the menu."""
-		self.board_fen_widget = MenuWidget(10, 100, 'GET FEN', pg.Color('white'), pg.Color('black'))
+		self.board_fen_widget = MenuWidget(
+			10, 100, 'fen_widget', 'GET FEN', pg.Color('black'), pg.Color('white')
+			)
 
 		self.widgets = self._init_widget_list()
 
-	def get_pressed_widget(self) -> Union[MenuWidget, None]:
+	def get_pressed_widget(self, mouse_x: int, mouse_y: int) -> Union[MenuWidget, None]:
+		"""Return the pressed widget on the chess menu."""
 		for widget in self.widgets:
-			pass
+			if point_in_rect(mouse_x, mouse_y, widget.rect):
+				return widget
 
-	def _init_widget_list(self) -> List:
+		return None  # this can be removed but explicit seems better
+
+	def _init_widget_list(self) -> List[MenuWidget]:
 		"""Initialize the list that contains every widget on the menu."""
-		return [getattr(self, key) for key in vars(self).keys()]
+		widgets = []
+		for key in vars(self).keys():
+			if '_widget' in key:
+				widgets.append(getattr(self, key))
+
+		return widgets
 
 	def render(self, surface):
 		for widget in self.widgets:
 			widget.render(surface)
+
+
+class ChessMenuHandler:
+	"""Handles events that happen when a on the chess menu button is clicked."""
+
+	def __init__(self, board_parser: BoardParser):
+		"""Initialize the handler for the chess menu."""
+		self.board_parser = board_parser
+
+	def handle(self, widget: MenuWidget):
+		"""Handle the pressed widget. Note: This method will never be passed 'None'"""
+		# TODO: Highlight pressed widget
+		if widget.id == 'fen_widget':
+			board_fen = self.board_parser.parse()
+			print(board_fen)

--- a/src/game/menu/chess_menu.py
+++ b/src/game/menu/chess_menu.py
@@ -21,7 +21,8 @@ class ChessMenu(Renderable):
 	def __init__(self):
 		"""Initialize the widgets on the menu."""
 		self.board_fen_widget = MenuWidget(
-			10, 100, 'fen_widget', 'GET FEN', pg.Color('black'), pg.Color('white')
+			30, 100, 'fen_widget', 'GET FEN', 
+			pg.Color('black'), pg.Color('white'), pg.Color('black')
 			)
 
 		self.widgets = self._init_widget_list()

--- a/src/game/menu/chess_menu.py
+++ b/src/game/menu/chess_menu.py
@@ -9,9 +9,9 @@ from fen_parser.board_parser import BoardParser
 from .menu_widget import MenuWidget
 from utils import point_in_rect
 
-# remove this later, move colors into its own module
-import pygame as pg
+import pygame as pg  # remove this later, move colors into its own module
 
+import tkinter.filedialog as fd
 import tkinter as tk
 
 
@@ -21,7 +21,7 @@ class ChessMenu(Renderable):
 	def __init__(self):
 		"""Initialize the widgets on the menu."""
 		self.board_fen_widget = MenuWidget(
-			30, 100, 'fen_widget', 'GET FEN', 
+			30, 100, 'fen_widget', 'SAVE FEN', 
 			pg.Color('black'), pg.Color('white'), pg.Color('black')
 			)
 
@@ -39,8 +39,9 @@ class ChessMenu(Renderable):
 		"""Initialize the list that contains every widget on the menu."""
 		widgets = []
 		for key in vars(self).keys():
-			if '_widget' in key:
-				widgets.append(getattr(self, key))
+			element = getattr(self, key)
+			if type(element) == MenuWidget:
+				widgets.append(element)
 
 		return widgets
 
@@ -58,7 +59,18 @@ class ChessMenuHandler:
 
 	def handle(self, widget: MenuWidget):
 		"""Handle the pressed widget. Note: This method will never be passed 'None'"""
-		# TODO: Highlight pressed widget
 		if widget.id == 'fen_widget':
+			# Get the FEN string for the position on the board
 			board_fen = self.board_parser.parse()
-			print(board_fen)
+
+			# Create tkinter window on our own so we can hide and close it
+			root = tk.Tk()
+			root.withdraw()
+
+			save_file = fd.asksaveasfile(defaultextension='.fen')
+			if save_file is not None:
+				save_file.write(board_fen)
+				save_file.close()
+
+			# Quit tkinter
+			root.destroy()

--- a/src/game/menu/menu_widget.py
+++ b/src/game/menu/menu_widget.py
@@ -12,6 +12,7 @@ class MenuWidget(Renderable):
 	MENU_FONT = pg.font.SysFont('monaco', 18)
 	WIDGET_HEIGHT = 60
 	WIDGET_WIDTH = 150
+	HIGHLIGHT_COLOR = pg.Color('red')  # TODO: change this
 
 	def __init__(
 			self, x:int, y:int, identifier: str, text:str, 
@@ -29,11 +30,19 @@ class MenuWidget(Renderable):
 		self.bg_color = bg_color
 		self.border_color = border_color
 
+		self._original_bg_color = bg_color
+
 		# Graphics
 		self.rect = self._init_rect()
 		self.border_rect = self._init_border_rect()
 		self.label = MenuWidget.MENU_FONT.render(text, True, self.text_color)
 		self.label_pos = self._center_label_pos()
+
+	def highlight(self):
+		self.bg_color = MenuWidget.HIGHLIGHT_COLOR
+
+	def unhighlight(self):
+		self.bg_color = self._original_bg_color
 
 	def _center_label_pos(self) -> Tuple[int, int]:
 		"""Centers the label inside the widget."""

--- a/src/game/menu/menu_widget.py
+++ b/src/game/menu/menu_widget.py
@@ -16,7 +16,8 @@ class MenuWidget(Renderable):
 	def __init__(
 			self, x:int, y:int, identifier: str, text:str, 
 			text_color: Tuple[int, int, int], 
-			bg_color: Tuple[int, int, int]
+			bg_color: Tuple[int, int, int],
+			border_color: Tuple[int, int, int]
 		):
 		"""Initialize the widget and the text inside it."""
 		self.x = x
@@ -26,9 +27,11 @@ class MenuWidget(Renderable):
 		self.text = text
 		self.text_color = text_color
 		self.bg_color = bg_color
+		self.border_color = border_color
 
 		# Graphics
 		self.rect = self._init_rect()
+		self.border_rect = self._init_border_rect()
 		self.label = MenuWidget.MENU_FONT.render(text, True, self.text_color)
 		self.label_pos = self._center_label_pos()
 
@@ -40,10 +43,19 @@ class MenuWidget(Renderable):
 		return center_x, center_y
 
 	def render(self, surface):
+		pg.draw.rect(surface, self.border_color, self.border_rect)
 		pg.draw.rect(surface, self.bg_color, self.rect)  # background
 		surface.blit(self.label, self.label_pos)  # text
 
-	def _init_rect(self) -> None:
+	def _init_rect(self) -> pg.Rect:
 		return pg.Rect(
 				self.x, self.y, MenuWidget.WIDGET_WIDTH, MenuWidget.WIDGET_HEIGHT
+			)
+
+	def _init_border_rect(self, border=2) -> pg.Rect:
+		"""Initialize the rect that composes the border of the widget."""
+		return pg.Rect(
+				self.x-border, self.y-border, 
+				MenuWidget.WIDGET_WIDTH+border+border, 
+				MenuWidget.WIDGET_HEIGHT+border+border
 			)

--- a/src/game/menu/menu_widget.py
+++ b/src/game/menu/menu_widget.py
@@ -1,0 +1,38 @@
+# Typing
+from typing import Tuple
+
+import pygame as pg
+
+from graphics import Renderable
+
+
+class MenuWidget(Renderable):
+	MENU_FONT = pg.font.SysFont('monospace', 18)
+	WIDGET_HEIGHT = 30
+	WIDGET_WIDTH = 100
+
+	def __init__(
+			self, x:int, y:int, text:str, 
+			text_color: Tuple[int, int, int], 
+			bg_color: Tuple[int, int, int]
+		):
+		self.x = x
+		self.y = y
+		self.pos = (self.x, self.y)
+
+		self.text = text
+		self.text_color = text_color
+		self.bg_color = bg_color
+
+		# Graphics
+		self.rect = self._init_rect()
+		self.label = MenuWidget.MENU_FONT.render(text, True, self.text_color)
+
+	def render(self, surface):
+		pg.draw.rect(surface, self.bg_color, self.rect)  # background
+		surface.blit(self.label, self.pos)  # text
+
+	def _init_rect(self) -> None:
+		return pg.Rect(
+				self.x, self.y, MenuWidget.WIDGET_WIDTH, MenuWidget.WIDGET_HEIGHT
+			)

--- a/src/game/menu/menu_widget.py
+++ b/src/game/menu/menu_widget.py
@@ -7,18 +7,21 @@ from graphics import Renderable
 
 
 class MenuWidget(Renderable):
-	MENU_FONT = pg.font.SysFont('monospace', 18)
-	WIDGET_HEIGHT = 30
-	WIDGET_WIDTH = 100
+	"""Represents a widget on the in-game menu."""
+	# TODO: Add some good styling to the widget
+	MENU_FONT = pg.font.SysFont('monaco', 18)
+	WIDGET_HEIGHT = 60
+	WIDGET_WIDTH = 150
 
 	def __init__(
-			self, x:int, y:int, text:str, 
+			self, x:int, y:int, identifier: str, text:str, 
 			text_color: Tuple[int, int, int], 
 			bg_color: Tuple[int, int, int]
 		):
+		"""Initialize the widget and the text inside it."""
 		self.x = x
 		self.y = y
-		self.pos = (self.x, self.y)
+		self.id = identifier
 
 		self.text = text
 		self.text_color = text_color
@@ -27,10 +30,18 @@ class MenuWidget(Renderable):
 		# Graphics
 		self.rect = self._init_rect()
 		self.label = MenuWidget.MENU_FONT.render(text, True, self.text_color)
+		self.label_pos = self._center_label_pos()
+
+	def _center_label_pos(self) -> Tuple[int, int]:
+		"""Centers the label inside the widget."""
+		center_x = (MenuWidget.WIDGET_WIDTH // 2) + self.x - (self.label.get_width() // 2)
+		center_y = (MenuWidget.WIDGET_HEIGHT // 2) + self.y - (self.label.get_height() // 2)
+
+		return center_x, center_y
 
 	def render(self, surface):
 		pg.draw.rect(surface, self.bg_color, self.rect)  # background
-		surface.blit(self.label, self.pos)  # text
+		surface.blit(self.label, self.label_pos)  # text
 
 	def _init_rect(self) -> None:
 		return pg.Rect(


### PR DESCRIPTION
Added a menu to the app. The menu is called the 'Chess Menu' and is next to the chessboard. As of this pull request, the menu only contains one widget that saves the current position as a FEN string.

Another thing to mention here is that DPI Awareness has been turned on, so the app has a much higher resolution now.